### PR TITLE
Gracefully handle CancelledError

### DIFF
--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -2,7 +2,7 @@
 import aiohttp
 import urllib
 
-# import asyncio
+import asyncio
 import jsonrpc_base
 import jsonrpc_async
 import jsonrpc_websocket

--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -133,7 +133,7 @@ class KodiWSConnection(KodiConnection):
             return
         try:
             await self._ws_server.ws_connect()
-        except jsonrpc_base.jsonrpc.TransportError as error:
+        except (jsonrpc_base.jsonrpc.TransportError, asyncio.exceptions.CancelledError) as error:
             raise CannotConnectError from error
 
     async def close(self):


### PR DESCRIPTION
Some connection attempts (e.g. when Kodi is on Windows 10 with WS turned off and default firewall config), result in CancelledError. Make sure to convert that into a CannotConnectError so that calling code can handle.