### PR TITLE
Simplify _build_query

### DIFF
--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -416,12 +416,7 @@ class Kodi:
 
 def _build_query(**kwargs):
     """Build query."""
-    query = {}
-    for key, val in kwargs.items():
-        if val:
-            query.update({key: val})
-
-    return query
+    return kwargs
 
 
 class CannotConnectError(Exception):


### PR DESCRIPTION
That function was not doing anything useful. Simply returning the kwargs dictionary is sufficient.