### PR TITLE
Fix parameters due to breaking changes in jsonrpc

### DIFF
--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -133,7 +133,10 @@ class KodiWSConnection(KodiConnection):
             return
         try:
             await self._ws_server.ws_connect()
-        except (jsonrpc_base.jsonrpc.TransportError, asyncio.exceptions.CancelledError) as error:
+        except (
+            jsonrpc_base.jsonrpc.TransportError,
+            asyncio.exceptions.CancelledError,
+        ) as error:
             raise CannotConnectError from error
 
     async def close(self):
@@ -260,7 +263,7 @@ class Kodi:
             await self._server.Player.Seek(players[0]["playerid"], time)
 
     async def play_item(self, item):
-        await self._server.Player.Open({"item": item})
+        await self._server.Player.Open(**{"item": item})
 
     async def play_channel(self, channel_id):
         """Play the given channel."""
@@ -283,7 +286,7 @@ class Kodi:
         players = await self.get_players()
         if players:
             await self._server.Player.SetShuffle(
-                {"playerid": players[0]["playerid"], "shuffle": shuffle}
+                **{"playerid": players[0]["playerid"], "shuffle": shuffle}
             )
 
     async def call_method(self, method, **kwargs):
@@ -291,8 +294,7 @@ class Kodi:
         return await getattr(self._server, method)(**kwargs)
 
     async def _add_item_to_playlist(self, item):
-        params = {"playlistid": 0, "item": item}
-        await self._server.Playlist.Add(params)
+        await self._server.Playlist.Add(**{"playlistid": 0, "item": item})
 
     async def add_song_to_playlist(self, song_id):
         """Add song to default playlist (i.e. playlistid=0)."""

--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -133,10 +133,7 @@ class KodiWSConnection(KodiConnection):
             return
         try:
             await self._ws_server.ws_connect()
-        except (
-            jsonrpc_base.jsonrpc.TransportError,
-            asyncio.exceptions.CancelledError,
-        ) as error:
+        except (jsonrpc_base.jsonrpc.TransportError, asyncio.exceptions.CancelledError) as error:
             raise CannotConnectError from error
 
     async def close(self):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
 VERSION = '0.2.3'
 
-REQUIRED = ['jsonrpc-async>=1.1.0', 'jsonrpc-websocket>=1.2.1', 'aiohttp']
+REQUIRED = ['jsonrpc-async>=2.0.0', 'jsonrpc-websocket>=3.0.0', 'aiohttp']
 
 EXTRAS = {}
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/OnFreund/PyKodi'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = '0.2.3'
+VERSION = '0.2.4'
 
 REQUIRED = ['jsonrpc-async>=2.0.0', 'jsonrpc-websocket>=3.0.0', 'aiohttp']
 


### PR DESCRIPTION
Bump required versions for `jsonrpc_base`, `jsonrpc_async` and `jsonrpc_websocket` due to breaking changes in [jsonrpc_async](https://github.com/emlove/jsonrpc-async#200-2021-03-16), [jsonrpc_base](https://github.com/emlove/jsonrpc-base#200-2021-03-16) and [jsonrpc_websocket](https://github.com/emlove/jsonrpc-websocket#300-2021-03-17).

Fix parameters as per recommendation in the [release notes](https://github.com/emlove/jsonrpc-async#200-2021-03-16).