### PR TITLE
Fix Player.Seek command parameters due to breaking changes in API/v12

### DIFF
--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -231,7 +231,7 @@ class Kodi:
             if direction == "previous":
                 # First seek to position 0. Kodi goes to the beginning of the
                 # current track if the current track is not at the beginning.
-                await self._server.Player.Seek(players[0]["playerid"], 0)
+                await self._server.Player.Seek(players[0]["playerid"], {"percentage": 0})
 
             await self._server.Player.GoTo(players[0]["playerid"], direction)
 
@@ -260,7 +260,7 @@ class Kodi:
         time["hours"] = int(position)
 
         if players:
-            await self._server.Player.Seek(players[0]["playerid"], time)
+            await self._server.Player.Seek(players[0]["playerid"], {"time": time})
 
     async def play_item(self, item):
         await self._server.Player.Open(**{"item": item})


### PR DESCRIPTION
https://kodi.wiki/view/JSON-RPC_API/v12#Player.Seek now require sending a named object instead of a value.

@cgtobi @OnFreund @MartinHjelmare guys please check and review.

The error I'm getting without this fix: 

`Failed to call service media_player/media_seek. (-32602, 'Invalid params.', {'error': {'code': -32602, 'data': {'method': 'Player.Seek', 'stack': {'message': 'Received value does not match any of the union type definitions', 'name': 'value', 'type': 'object'}}, 'message': 'Invalid params.'}, 'id': 510099538, 'jsonrpc': '2.0'})
`