### PR TITLE
Close connection when connecting to server fails

### DIFF
--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -137,6 +137,7 @@ class KodiWSConnection(KodiConnection):
             jsonrpc_base.jsonrpc.TransportError,
             asyncio.exceptions.CancelledError,
         ) as error:
+            await self._ws_server.close()
             raise CannotConnectError from error
 
     async def close(self):


### PR DESCRIPTION
I was fixing a bug with the HA integration when I was pointed to this ticket: https://github.com/home-assistant/core/issues/67954

A brief look at the code says that the websockets are managed entirely within this package. If that's true, this is the only place where I see a leak of connections could be possible.