### PR TITLE
Improve _build_query time

### DIFF
--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -418,12 +418,7 @@ class Kodi:
 
 def _build_query(**kwargs):
     """Build query."""
-    query = {}
-    for key, val in kwargs.items():
-        if val:
-            query.update({key: val})
-
-    return query
+    return {key: val for key, val in kwargs.items() if val is not None}
 
 
 class CannotConnectError(Exception):


### PR DESCRIPTION
The process of updating the dictionary over and over with a new dictionary will be slower than using dict comprehension. Not sure how much of a speed up you'll gain but it's a small change that at worst barely makes a difference but at best makes a slight difference.

Also is the intent to make sure val is not `None`? I assumed it is because this will filter out when val=0 or False as well, but if that's not correct I can update this