### PR TITLE
Add error checking to call_method

### DIFF
--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -265,7 +265,7 @@ class Kodi:
             await self._server.Player.Seek(players[0]["playerid"], {"time": time})
 
     async def play_item(self, item):
-        await self._server.Player.Open(item=item)
+        await self._server.Player.Open(**{"item": item})
 
     async def play_channel(self, channel_id):
         """Play the given channel."""
@@ -288,7 +288,7 @@ class Kodi:
         players = await self.get_players()
         if players:
             await self._server.Player.SetShuffle(
-                playerid=players[0]["playerid"], shuffle=shuffle
+                **{"playerid": players[0]["playerid"], "shuffle": shuffle}
             )
 
     async def call_method(self, method, **kwargs):
@@ -298,7 +298,7 @@ class Kodi:
         return await getattr(self._server, method)(**kwargs)
 
     async def _add_item_to_playlist(self, item):
-        await self._server.Playlist.Add(playlistid=0, item=item)
+        await self._server.Playlist.Add(**{playlistid: 0, item: item})
 
     async def add_song_to_playlist(self, song_id):
         """Add song to default playlist (i.e. playlistid=0)."""
@@ -314,7 +314,7 @@ class Kodi:
 
     async def clear_playlist(self):
         """Clear default playlist (i.e. playlistid=0)."""
-        await self._server.Playlist.Clear(playlistid=0)
+        await self._server.Playlist.Clear(**{playlistid: 0})
 
     async def get_artists(self, properties=None):
         """Get artists list."""

--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -231,7 +231,9 @@ class Kodi:
             if direction == "previous":
                 # First seek to position 0. Kodi goes to the beginning of the
                 # current track if the current track is not at the beginning.
-                await self._server.Player.Seek(players[0]["playerid"], {"percentage": 0})
+                await self._server.Player.Seek(
+                    players[0]["playerid"], {"percentage": 0}
+                )
 
             await self._server.Player.GoTo(players[0]["playerid"], direction)
 
@@ -263,7 +265,7 @@ class Kodi:
             await self._server.Player.Seek(players[0]["playerid"], {"time": time})
 
     async def play_item(self, item):
-        await self._server.Player.Open(**{"item": item})
+        await self._server.Player.Open(item=item)
 
     async def play_channel(self, channel_id):
         """Play the given channel."""
@@ -286,15 +288,17 @@ class Kodi:
         players = await self.get_players()
         if players:
             await self._server.Player.SetShuffle(
-                **{"playerid": players[0]["playerid"], "shuffle": shuffle}
+                playerid=players[0]["playerid"], shuffle=shuffle
             )
 
     async def call_method(self, method, **kwargs):
         """Run Kodi JSONRPC API method with params."""
+        if "." not in method or len(method.split(".")) != 2:
+            raise ValueError(f"Invalid method: {method}")
         return await getattr(self._server, method)(**kwargs)
 
     async def _add_item_to_playlist(self, item):
-        await self._server.Playlist.Add(**{"playlistid": 0, "item": item})
+        await self._server.Playlist.Add(playlistid=0, item=item)
 
     async def add_song_to_playlist(self, song_id):
         """Add song to default playlist (i.e. playlistid=0)."""
@@ -310,7 +314,7 @@ class Kodi:
 
     async def clear_playlist(self):
         """Clear default playlist (i.e. playlistid=0)."""
-        await self._server.Playlist.Clear(**{"playlistid": 0})
+        await self._server.Playlist.Clear(playlistid=0)
 
     async def get_artists(self, properties=None):
         """Get artists list."""

--- a/pykodi/kodi.py
+++ b/pykodi/kodi.py
@@ -298,7 +298,7 @@ class Kodi:
         return await getattr(self._server, method)(**kwargs)
 
     async def _add_item_to_playlist(self, item):
-        await self._server.Playlist.Add(**{playlistid: 0, item: item})
+        await self._server.Playlist.Add(**{"playlistid": 0, "item": item})
 
     async def add_song_to_playlist(self, song_id):
         """Add song to default playlist (i.e. playlistid=0)."""
@@ -314,7 +314,7 @@ class Kodi:
 
     async def clear_playlist(self):
         """Clear default playlist (i.e. playlistid=0)."""
-        await self._server.Playlist.Clear(**{playlistid: 0})
+        await self._server.Playlist.Clear(**{"playlistid": 0})
 
     async def get_artists(self, properties=None):
         """Get artists list."""


### PR DESCRIPTION
~~I was thinking it would be useful to have a service in HA that lets you call a generic Kodi method.~~ And I just found the service looking at the integration code, guess I should have looked there first!

Looking at the code I found `call_method` but it doesn't do any error checking so I added that in. ~~There were also a couple of places where you were doing unnecessary dictionary unpacking when you could pass in keyword arguments directly.~~